### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -24,8 +30,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -50,8 +57,22 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": [
+        "alpine_3_24/ffmpeg",
+        "alpine_3_24/ffmpeg-dev",
+        "alpine_3_24/ffmpeg-libs",
+        "alpine_3_24/v4l-utils",
+        "alpine_3_24/v4l-utils-dev"
+      ],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "Add-on base image",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the organisation. Every `alpine_X_YY/*` lookup returns `no-result`, so Alpine pins are no longer updated at all, and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and each run resolves every pin through it.

This replaces it with a custom datasource that reads the Alpine CDN directory listings directly, applying the same change that already landed on app-ssh in hassio-addons/app-ssh#1119.

- Adds a `customDatasources` entry pointing at `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/` using the `html` format, so each `href` in the directory listing becomes a version candidate.
- Switches the Alpine custom manager to `custom.alpine` and adds `extractVersionTemplate` to pull the version out of the `.apk` filename. The leading `\d` in that pattern matters: without it a package would also match its own `-syntax`/`-doc` style siblings.
- Switches the `repology` package rule to `custom.alpine`.
- Adds a rule listing the pins that live in the Alpine **community** repository. Custom datasources use `registryStrategy: "first"`, so multiple `registryUrls` are not hunted and community packages would otherwise fail to resolve. For this repository that is `ffmpeg`, `ffmpeg-dev`, `ffmpeg-libs`, `v4l-utils` and `v4l-utils-dev`.

The community list was derived mechanically from this repository's `Dockerfile` against the `v3.24` `main` and `community` `APKINDEX` files, not copied from app-ssh.

## Verification

A passing CI build proves nothing here, since the config change does not touch the `Dockerfile` and the `apk` layer is served from cache. The evidence is a local dry-run instead:

- `renovate-config-validator` passes.
- A `RENOVATE_DRY_RUN=lookup` run resolves **all 29** Alpine pins from the Dockerfile, with **zero** `Found no results` and zero Alpine lookup failures. Both registry URLs are exercised, `main` and `community`.
- The only lookup failures in the log are `github-digest` and `github-releases` entries needing a GitHub token, which the local container has no credentials for. They are unrelated to this change.
- Cross-checked every pin against the `main` and `community` `APKINDEX` files: all 29 are already at the newest published version, which agrees with Renovate reporting no Alpine updates. No pin in this repository is stale, and none is missing from both indexes.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Applies the same fix as hassio-addons/app-ssh#1119.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated update detection for Alpine Linux packages.
  * Enabled automatic merging for eligible Alpine package updates.
  * Added support for resolving packages from the Alpine community repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->