### PR TITLE
🐛 Use the http2 directive instead of the deprecated listen parameter

### DIFF
--- a/motioneye/rootfs/etc/nginx/templates/direct.gtpl
+++ b/motioneye/rootfs/etc/nginx/templates/direct.gtpl
@@ -2,7 +2,8 @@ server {
     {{ if not .ssl }}
     listen {{ .port }} default_server;
     {{ else }}
-    listen {{ .port }} default_server ssl http2;
+    listen {{ .port }} default_server ssl;
+    http2 on;
     {{ end }}
 
     include /etc/nginx/includes/server_params.conf;


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

NGINX deprecated the `http2` parameter on the `listen` directive back in 1.25.1, in favour of a standalone `http2` directive. This app now ships NGINX 1.30.4, so anyone using direct access with SSL enabled gets this on every start:

```
nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/servers/direct.conf:2
```

The non-SSL branch of the template never set `http2`, so it is unaffected.

## Verification

Rendered `direct.gtpl` with `tempio` inside the built image, using the same `bashio::var.json` call the init script makes, then ran `nginx -t` on the result:

- `ssl: true` renders `listen 8443 default_server ssl;` followed by `http2 on;`, and `nginx -t` passes with the deprecation warning gone.
- `ssl: false` renders `listen 8080 default_server;` unchanged, and `nginx -t` passes.

Tested against a realistic certificate chain (leaf plus issuer), not a bare self-signed cert.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Found during a general review of the app.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP/2 configuration for secure connections to use the current supported nginx directive format.
  * Non-secure connection behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->