### PR TITLE
🐛 Wait longer for motionEye to become available

### DIFF
--- a/motioneye/rootfs/etc/s6-overlay/s6-rc.d/discovery/run
+++ b/motioneye/rootfs/etc/s6-overlay/s6-rc.d/discovery/run
@@ -7,7 +7,7 @@
 declare config
 
 # Wait for motionEye to start before continuing
-bashio::net.wait_for 28765
+bashio::net.wait_for 28765 127.0.0.1 300
 
 # Create discovery config payload for Home Assistant
 config=$(bashio::var.json \

--- a/motioneye/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/motioneye/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -6,7 +6,7 @@
 # ==============================================================================
 
 # Wait for motionEye to be available
-bashio::net.wait_for 28765
+bashio::net.wait_for 28765 127.0.0.1 300
 
 bashio::log.info "Starting NGinx..."
 exec nginx


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Both the NGINX and the discovery service wait for motionEye to come up before continuing, but they called `bashio::net.wait_for` with only a port:

```bash
bashio::net.wait_for 28765
```

That falls back to the helper's defaults, which are `localhost` and a **60 second** timeout:

```bash
bashio::net.wait_for() {
    local port=${1}
    local host=${2:-'localhost'}
    local timeout=${3:-60}
```

The helper's wait ends in `|| true` and it always returns `__BASHIO_EXIT_OK`, so it never signals that the wait was unsuccessful. It just stops waiting after a minute and the caller carries on regardless.

On slower hardware, on a first start where the configuration migration runs, or with a larger number of cameras, motionEye can take longer than 60 seconds to listen. When that happens:

- NGINX starts against an upstream that is not accepting connections yet.
- Discovery announces the app to Home Assistant before it can answer, so the integration is set up against a service that is not ready.

This raises the timeout to 300 seconds and passes the host explicitly, which is exactly what `app-uptime-kuma` and `app-adguard-home` already do:

```bash
bashio::net.wait_for 3001 127.0.0.1 300
```

Note this only changes how long the services are willing to wait. When motionEye starts promptly, which is the normal case, behaviour is unchanged and nothing waits any longer than before.

## Verification

Shellcheck passes on all S6 service scripts.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Found during a general review of the app.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup reliability by ensuring internal components wait for the local motionEye service to become available before continuing.
  * Added an explicit connection timeout to prevent startup checks from waiting indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->