### PR TITLE
🔥 Remove OCSP stapling, which can no longer work

### DIFF
--- a/motioneye/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/motioneye/rootfs/etc/nginx/includes/ssl_params.conf
@@ -4,5 +4,3 @@ ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDS
 ssl_session_timeout  10m;
 ssl_session_cache shared:SSL:10m;
 ssl_session_tickets off;
-ssl_stapling on;
-ssl_stapling_verify on;


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`ssl_params.conf` enables OCSP stapling:

```nginx
ssl_stapling on;
ssl_stapling_verify on;
```

Stapling only does anything when the served certificate carries an OCSP responder URL. Let's Encrypt, which is realistically where certificates for this app come from, has retired OCSP and no longer includes a responder URL in the certificates it issues. Checking a live Let's Encrypt certificate confirms it:

```
$ echo | openssl s_client -connect letsencrypt.org:443 -servername letsencrypt.org \
    | openssl x509 -noout -ocsp_uri -issuer
issuer=C = US, O = Let's Encrypt, CN = YE2
```

No OCSP URI is printed at all. So for the common case NGINX staples nothing and logs a warning on every start when direct access is used with SSL:

```
nginx: [warn] "ssl_stapling" ignored, no OCSP responder URL in the certificate "/ssl/fullchain.pem"
```

This removes the two directives, leaving a clean configuration test.

## A note on the trade-off

This is a judgement call worth a second opinion. If someone supplies a certificate from a CA that still runs an OCSP responder, stapling currently works for them and this removes that small privacy and latency benefit. The directives are harmless when they do work, they simply warn when they do not.

The argument for removing them is that stapling is being retired across the ecosystem, the dominant certificate source for this app no longer supports it, and dead configuration that warns on every start is worse than no configuration. Happy to close this if you would rather keep them for the CAs that still support OCSP.

## Verification

Ran `nginx -t` inside the built image against a realistic certificate chain (leaf plus issuer, not a bare self-signed cert):

- Before: `nginx: [warn] "ssl_stapling" ignored, no OCSP responder URL in the certificate`
- After: no warnings, configuration test successful.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Found during a general review of the app.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
