### PR TITLE
📝 Fix typos and refresh the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Simple, elegant and feature-rich CCTV/NVR for your cameras.
 ## About
 
 motionEye is a popular frontend to the camera software called motion. This
-app provides both, allowing you to add your cameras to your Hass.io setup.
+app provides both, allowing you to add your cameras to your Home Assistant
+setup.
 
 motionEye is Open Source CCTV and NVR, that is elegant and really easy to use.
 It can be used as a Baby Monitor, Construction Site Montage Viewer,
@@ -30,8 +31,8 @@ Some cool features of motionEye:
 - Support for a ridiculous amount of cameras, including IP cams.
 - Add multiple cameras by hooking up multiple motionEye instances together.
   For example, by using MotionEyeOS on a Pi Zero + Pi camera in your network.
-- Supports uploading recording into Google Drive and Dropbox.
-- motion detection, including email notification and scheduling.
+- Supports uploading recordings to Google Drive and Dropbox.
+- Motion detection, including email notification and scheduling.
 - Can record continuously, motion, or timelapse, with retention settings.
 - Supports "[action buttons][motioneye-wiki-action-buttons]" within the configuration.
 
@@ -50,7 +51,7 @@ You have several options to get them answered:
 - The Home Assistant [Community Forum][forum].
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
 
-You could also [open an issue here][issue] GitHub.
+You could also [open an issue here][issue] on GitHub.
 
 ## Contributing
 
@@ -115,7 +116,7 @@ SOFTWARE.
 [issue]: https://github.com/hassio-addons/app-motioneye/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/app-motioneye.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
-[motioneye-wiki-action-buttons]: https://github.com/ccrisan/motioneye/wiki/Action-Buttons
+[motioneye-wiki-action-buttons]: https://github.com/motioneye-project/motioneye/wiki/Action-Buttons
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png
 [patreon]: https://www.patreon.com/frenck
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg

--- a/motioneye/.README.j2
+++ b/motioneye/.README.j2
@@ -10,7 +10,7 @@ Simple, elegant and feature-rich CCTV/NVR for your cameras.
 
 ## About
 
-motionEye is a popular frontend to the camera software called motion. This app provides both, allowing you to add your camera's to your Hass.io setup.
+motionEye is a popular frontend to the camera software called motion. This app provides both, allowing you to add your cameras to your Home Assistant setup.
 
 motionEye is Open Source CCTV and NVR, that is elegant and really easy to use. It can be used as a Baby Monitor, Construction Site Montage Viewer, Store Camera DVR, Garden Security, and much more.
 
@@ -19,8 +19,8 @@ Some cool features of motionEye:
 - Support for a ridiculous amount of cameras, including IP cams.
 - Add multiple cameras by hooking up multiple motionEye instances together.
   For example, by using MotionEyeOS on a Pi Zero + Pi camera in your network.
-- Supports uploading recording into Google Drive and Dropbox.
-- motion detection, including email notification and scheduling.
+- Supports uploading recordings to Google Drive and Dropbox.
+- Motion detection, including email notification and scheduling.
 - Can record continuously, motion, or timelapse, with retention settings.
 
 ![motionEye screenshot][screenshot]

--- a/motioneye/DOCS.md
+++ b/motioneye/DOCS.md
@@ -1,7 +1,8 @@
 # Home Assistant Community App: motionEye
 
 motionEye is a popular frontend to the camera software called motion. This
-app provides both, allowing you to add your camera's to your Hass.io setup.
+app provides both, allowing you to add your cameras to your Home Assistant
+setup.
 
 motionEye is Open Source CCTV and NVR, that is elegant and really easy to use.
 It can be used as a Baby Monitor, Construction Site Montage Viewer,
@@ -12,8 +13,8 @@ Some cool features of motionEye:
 - Support for a ridiculous amount of cameras, including IP cams.
 - Add multiple cameras by hooking up multiple motionEye instances together.
   For example, by using MotionEyeOS on a Pi Zero + Pi camera in your network.
-- Supports uploading recording into Google Drive and Dropbox.
-- motion detection, including email notification and scheduling.
+- Supports uploading recordings to Google Drive and Dropbox.
+- Motion detection, including email notification and scheduling.
 - Can record continuously, motion, or timelapse, with retention settings.
 - Supports "[action buttons][motioneye-wiki-action-buttons]" within the configuration.
 
@@ -37,9 +38,9 @@ comparison to installing any other Home Assistant app.
 
 Home Assistant, by default, ships with the Community Apps store installed.
 However, if it is missing (for any reason), you can add it by clicking the
-button My button below.
+My button below.
 
-[![Add repository to your Home Assitant instance.][repository-badge]][repository]
+[![Add repository to your Home Assistant instance.][repository-badge]][repository]
 
 ## Configuration
 
@@ -161,7 +162,7 @@ You have several options to get them answered:
 - The Home Assistant [Community Forum][forum].
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
 
-You could also [open an issue here][issue] GitHub.
+You could also [open an issue here][issue] on GitHub.
 
 ## Authors & contributors
 
@@ -199,7 +200,6 @@ SOFTWARE.
 [contributors]: https://github.com/hassio-addons/app-motioneye/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
-[dockerhub]: https://hub.docker.com/r/hassioaddons/motioneye
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-motioneye/71826?u=frenck
 [frenck]: https://github.com/frenck
 [issue]: https://github.com/hassio-addons/app-motioneye/issues

--- a/motioneye/rootfs/etc/s6-overlay/s6-rc.d/discovery/run
+++ b/motioneye/rootfs/etc/s6-overlay/s6-rc.d/discovery/run
@@ -16,7 +16,7 @@ config=$(bashio::var.json \
 
 # Send discovery info
 if bashio::discovery "motioneye" "${config}" > /dev/null; then
-    bashio::log.info "Successfully send discovery information to Home Assistant."
+    bashio::log.info "Successfully sent discovery information to Home Assistant."
 else
     bashio::log.error "Discovery message to Home Assistant failed!"
 fi

--- a/motioneye/rootfs/etc/s6-overlay/s6-rc.d/init-motioneye/run
+++ b/motioneye/rootfs/etc/s6-overlay/s6-rc.d/init-motioneye/run
@@ -65,7 +65,7 @@ if bashio::config.has_value 'action_buttons'; then
         button_command=$(bashio::config "action_buttons[${button}].command")
         bashio::log.debug "File: ${button_type}_${camera_number}, Command: ${button_command}"
         {
-            echo "#!/usr/bin/with-contenv bashio"
+            echo "#!/command/with-contenv bashio"
             echo "${button_command}"
         } > "/data/motioneye/${button_type}_${camera_number}"
         chmod +x "/data/motioneye/${button_type}_${camera_number}"

--- a/motioneye/rootfs/etc/s6-overlay/s6-rc.d/motioneye/run
+++ b/motioneye/rootfs/etc/s6-overlay/s6-rc.d/motioneye/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 # ==============================================================================
 # Home Assistant Community App: motionEye
-# Runs the motionEye
+# Runs the motionEye daemon
 # ==============================================================================
 declare -a options
 
@@ -15,5 +15,5 @@ if bashio::debug; then
     options+=(-d)
 fi
 
-# Run the motionEye
+# Run the motionEye daemon
 exec meyectl startserver "${options[@]}"

--- a/motioneye/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/motioneye/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -8,5 +8,5 @@
 # Wait for motionEye to be available
 bashio::net.wait_for 28765
 
-bashio::log.info "Starting NGinx..."
+bashio::log.info "Starting NGINX..."
 exec nginx

--- a/motioneye/translations/en.yaml
+++ b/motioneye/translations/en.yaml
@@ -16,16 +16,16 @@ configuration:
     name: Certificate file
     description: >-
       The certificate file to use for SSL. Note that this file must
-      exists in the /ssl/ folder.
+      exist in the /ssl/ folder.
   keyfile:
     name: Private key file
     description: >-
       The private key file to use for SSL. Note that this file must
-      exists in the /ssl/ folder.
+      exist in the /ssl/ folder.
   action_buttons:
     name: Action buttons
     description: >-
-      If configured, a script will be created to implement an motionEye
+      If configured, a script will be created to implement a motionEye
       action button. See app documentation for usage details.
 network:
   80/tcp: Web interface (Not required for Ingress)


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

A batch of small corrections found during a review of the app. No behaviour changes.

## User facing strings

- The discovery service logged **"Successfully send** discovery information". Now "sent", which is what `app-uptime-kuma` and `app-zwave-js-ui` already say.
- The certificate and private key descriptions, which render in the Home Assistant configuration panel, said a file **"must exists"** in the `/ssl/` folder.
- The action buttons description said **"an motionEye** action button".
- NGINX was logged as **"NGinx"** on start, where the rest of the app writes "NGINX".

## Documentation

- Drops the retired **"Hass.io"** branding for "Home Assistant", in the README, the docs and the template.
- **"your camera's"** is a plural here, not a possessive. The README already had this right, the docs and the template did not, so the three files disagreed with each other.
- **"uploading recording into"** becomes "uploading recordings to", and the motion detection bullet now starts capitalised like every other bullet in the list.
- **"open an issue here][issue] GitHub."** was missing its preposition, in both the README and the docs.
- **"clicking the button My button below"** had a stray word, and the repository badge read **"Home Assitant"**.
- The README pointed the action buttons link at `ccrisan/motioneye`, which only 301-redirects now. It matches the docs and points at `motioneye-project/motioneye`. Confirmed with `curl`: the old URL returns 301, the new one returns 200.
- Removes the `[dockerhub]` link reference, which was defined but never used.

## One consistency fix

Generated action button scripts were written with `#!/usr/bin/with-contenv bashio`, where everything else in the app uses `/command/with-contenv`. The old path is only a symlink to the new one, resolving to `/package/admin/s6-overlay-3.2.3.2/command/with-contenv` in the built image, so this is a consistency fix rather than a behaviour change. Folding it in here rather than opening a separate PR for a one-line cosmetic change.

## Verification

- Prettier, YAMLLint and Shellcheck all pass.
- Parsed `translations/en.yaml` and printed every rendered description to confirm the folded YAML scalars still read correctly after editing across line breaks.
- Re-wrapped the one paragraph whose edit pushed it past the file's prose width.

## Not included

The `log_level` documentation omits `notice`, which the schema accepts. That is template drift shared across the organisation, `app-ssh` omits both `notice` and `fatal`, so it seems better fixed upstream than diverged here.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Found during a general review of the app.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
